### PR TITLE
Fixed 'ArgumentException'

### DIFF
--- a/Assets/uPalette/Editor/Core/Shared/UPaletteEditorApplication.cs
+++ b/Assets/uPalette/Editor/Core/Shared/UPaletteEditorApplication.cs
@@ -87,8 +87,9 @@ namespace uPalette.Editor.Core.Shared
             _paletteEditorWindow?.Reload();
             _themeEditorWindow?.Reload();
             
-            var activeScene = SceneManager.GetActiveScene().path;
-            EditorSceneManager.OpenScene(activeScene);
+            var activeScenePath = SceneManager.GetActiveScene().path;
+            if (!string.IsNullOrEmpty(activeScenePath)) // Open the scene only if the scene is saved as an asset = if there is a path
+                EditorSceneManager.OpenScene(activeScenePath);
         }
 
         public static UPaletteEditorApplication RequestInstance()


### PR DESCRIPTION
uPaletteStore がインポートされた時にアセットとして保存されていないシーンを開いていると`ArgumentException: Scene file not found: ''.`が発生する不具合を修正

Fixed a bug where ArgumentException: Scene file not found: '' would occur when importing uPaletteStore while a scene that hasn't been saved as an asset is open.