### PR TITLE
Palette EditorのApplyメニューで複数Synchronizerがある場合のみ区別して表示するよう修正

### DIFF
--- a/Assets/Demo/Demo.unity
+++ b/Assets/Demo/Demo.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657815, g: 0.49641192, b: 0.57481617, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -616,6 +616,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -737,6 +738,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -979,6 +981,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -1179,6 +1182,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -1389,6 +1393,7 @@ Light:
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &655608219
@@ -1958,7 +1963,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1047965424}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: eaf4666aa7bdb4623b9444317e86fd7e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -2387,6 +2392,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -2508,6 +2514,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -2648,6 +2655,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!223 &1289664147
 Canvas:
   m_ObjectHideFlags: 0
@@ -2765,6 +2773,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -3536,6 +3545,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -3672,6 +3682,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -3974,6 +3985,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -4201,6 +4213,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}

--- a/Assets/Demo/TestImage.cs
+++ b/Assets/Demo/TestImage.cs
@@ -1,0 +1,5 @@
+using Image = UnityEngine.UI.Image;
+
+public class TestImage : Image
+{
+}

--- a/Assets/Demo/TestImage.cs.meta
+++ b/Assets/Demo/TestImage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eaf4666aa7bdb4623b9444317e86fd7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Demo/TestSynchronizer.cs
+++ b/Assets/Demo/TestSynchronizer.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+using uPalette.Runtime.Core.Synchronizer.Color;
+
+[DisallowMultipleComponent]
+[RequireComponent(typeof(TestImage))]
+[ColorSynchronizer(typeof(TestImage), "Color")]
+public sealed class TestSynchronizer : ColorSynchronizer<TestImage>
+{
+    [SerializeField] [Header("alphaを同期するか")]
+    private bool _syncAlpha;
+
+    public bool SyncAlpha
+    {
+        get => _syncAlpha;
+        set => _syncAlpha = value;
+    }
+
+    protected override Color GetValue()
+    {
+        return Component.color;
+    }
+
+    protected override void SetValue(Color value)
+    {
+        Component.color = value;
+    }
+}

--- a/Assets/Demo/TestSynchronizer.cs.meta
+++ b/Assets/Demo/TestSynchronizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9af36c2e80ad44dd1962d4406ada3926
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- 同一Component/Propertyに複数のSynchronizerが存在する場合、メニュー項目にSynchronizer名を含める
- Synchronizerが1つしかない場合は従来通りの表示を維持
- TestImageの場合: "Test Image Color/Graphic Color Synchronizer"と"Test Image Color/Test Synchronizer"
- 通常の場合: "Image Color"のような従来の表示