### PR TITLE
CharacterStyleTMPにフォントマテリアルの切り替え機能を追加

### DIFF
--- a/Assets/Demo/PaletteStore.asset
+++ b/Assets/Demo/PaletteStore.asset
@@ -215,6 +215,7 @@ MonoBehaviour:
               wordSpacing: 0
               lineSpacing: 0
               paragraphSpacing: 0
+              fontSharedMaterial: {fileID: 0}
           - _value:
               font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
               fontStyle: 1
@@ -229,6 +230,7 @@ MonoBehaviour:
               wordSpacing: 0
               lineSpacing: 0
               paragraphSpacing: 0
+              fontSharedMaterial: {fileID: 2180264, guid: 2e498d1c8094910479dc3e1b768306a4, type: 2}
           - _value:
               font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
               fontStyle: 1
@@ -243,6 +245,7 @@ MonoBehaviour:
               wordSpacing: 0
               lineSpacing: 0
               paragraphSpacing: 0
+              fontSharedMaterial: {fileID: 0}
       - _id: 40b83e6c-74e3-4f98-ac6a-f8c4705ad8a9
         _name:
           _value: Title
@@ -255,7 +258,7 @@ MonoBehaviour:
           - _value:
               font: {fileID: 11400000, guid: a9afcabfe81ac4e7281a9df4b6a11e78, type: 2}
               fontStyle: 32
-              fontSize: 136.1
+              fontSize: 137.05
               enableAutoSizing: 0
               enableAutoSizeOptions: 1
               fontSizeMin: 18
@@ -266,10 +269,11 @@ MonoBehaviour:
               wordSpacing: 0
               lineSpacing: 0
               paragraphSpacing: 0
+              fontSharedMaterial: {fileID: 2100000, guid: 7e8b6a12ee81f4b8189f99ab1633d937, type: 2}
           - _value:
               font: {fileID: 11400000, guid: b81fdff2855c444e68579f3df0109e91, type: 2}
               fontStyle: 32
-              fontSize: 134.7
+              fontSize: 168.45
               enableAutoSizing: 0
               enableAutoSizeOptions: 1
               fontSizeMin: 18
@@ -280,6 +284,7 @@ MonoBehaviour:
               wordSpacing: 0
               lineSpacing: 0
               paragraphSpacing: 0
+              fontSharedMaterial: {fileID: 0}
           - _value:
               font: {fileID: 11400000, guid: 855ef1fd6df214cfbb3c753d5f5567d5, type: 2}
               fontStyle: 33
@@ -294,6 +299,7 @@ MonoBehaviour:
               wordSpacing: 0
               lineSpacing: 0
               paragraphSpacing: 0
+              fontSharedMaterial: {fileID: 0}
       - _id: 066cbf8f-8b4a-441c-937e-c234e2780b88
         _name:
           _value: Main Button
@@ -317,6 +323,7 @@ MonoBehaviour:
               wordSpacing: 0
               lineSpacing: 0
               paragraphSpacing: 0
+              fontSharedMaterial: {fileID: 0}
           - _value:
               font: {fileID: 11400000, guid: b81fdff2855c444e68579f3df0109e91, type: 2}
               fontStyle: 32
@@ -331,6 +338,7 @@ MonoBehaviour:
               wordSpacing: 0
               lineSpacing: 0
               paragraphSpacing: 0
+              fontSharedMaterial: {fileID: 0}
           - _value:
               font: {fileID: 11400000, guid: 855ef1fd6df214cfbb3c753d5f5567d5, type: 2}
               fontStyle: 33
@@ -345,6 +353,7 @@ MonoBehaviour:
               wordSpacing: 0
               lineSpacing: 0
               paragraphSpacing: 0
+              fontSharedMaterial: {fileID: 0}
     _themes:
       _keys:
       - 10a7c335-bf25-4867-8af2-dd1b19273382

--- a/Assets/uPalette/Editor/Foundation/CharacterStyles/CharacterStyleTMPEditor.cs
+++ b/Assets/uPalette/Editor/Foundation/CharacterStyles/CharacterStyleTMPEditor.cs
@@ -30,6 +30,7 @@ namespace uPalette.Editor.Foundation.CharacterStyles
             var wordSpacingDisplayName = "Word";
             var lineSpacingDisplayName = "Line";
             var paragraphSpacingDisplayName = "Paragraph";
+            var fontSharedMaterialDisplayName = "Font Material";
 
             _characterStyle.font = (TMP_FontAsset)EditorGUILayout.ObjectField(fontDisplayName, _characterStyle.font,
                 typeof(TMP_FontAsset), false);
@@ -67,6 +68,46 @@ namespace uPalette.Editor.Foundation.CharacterStyles
             _characterStyle.paragraphSpacing =
                 EditorGUILayout.FloatField(paragraphSpacingDisplayName, _characterStyle.paragraphSpacing);
             EditorGUI.indentLevel--;
+
+            // フォントマテリアル
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.PrefixLabel(fontSharedMaterialDisplayName);
+
+            if (_characterStyle.fontSharedMaterial == null)
+            {
+                // マテリアルが設定されていない場合のプレースホルダー表示
+                var placeholderStyle = new GUIStyle(EditorStyles.objectField);
+                placeholderStyle.normal.textColor = Color.gray;
+
+                var defaultMaterialName = "(Default)";
+
+                if (GUILayout.Button(defaultMaterialName, placeholderStyle))
+                    // ObjectFieldと同じようにマテリアル選択ウィンドウを開く
+                    EditorGUIUtility.ShowObjectPicker<Material>(null,
+                        false,
+                        string.Empty,
+                        GUIUtility.GetControlID(FocusType.Passive));
+
+                // ObjectPickerからの選択を処理
+                if (Event.current.commandName == "ObjectSelectorUpdated")
+                {
+                    var pickedObject = EditorGUIUtility.GetObjectPickerObject();
+                    if (pickedObject is Material material)
+                    {
+                        _characterStyle.fontSharedMaterial = material;
+                        GUI.changed = true;
+                    }
+                }
+            }
+            else
+            {
+                _characterStyle.fontSharedMaterial = (Material)EditorGUILayout.ObjectField(
+                    _characterStyle.fontSharedMaterial,
+                    typeof(Material),
+                    false);
+            }
+
+            EditorGUILayout.EndHorizontal();
 
             if (EditorGUI.EndChangeCheck())
                 OnValueChanged?.Invoke(_characterStyle);
@@ -160,6 +201,9 @@ namespace uPalette.Editor.Foundation.CharacterStyles
             height += EditorGUIUtility.singleLineHeight;
             height += EditorGUIUtility.standardVerticalSpacing;
             // Paragraph Spacing
+            height += EditorGUIUtility.singleLineHeight;
+            height += EditorGUIUtility.standardVerticalSpacing;
+            // Font Material
             height += EditorGUIUtility.singleLineHeight;
             height += EditorGUIUtility.standardVerticalSpacing;
             // Padding

--- a/Assets/uPalette/Editor/Foundation/CharacterStyles/CharacterStyleTMPEditorGUILayout.cs
+++ b/Assets/uPalette/Editor/Foundation/CharacterStyles/CharacterStyleTMPEditorGUILayout.cs
@@ -64,7 +64,15 @@ namespace uPalette.Editor.Foundation.CharacterStyles
             }
 
             EditorGUI.LabelField(previewRect, previewLabel, previewGuiStyle);
-            EditorGUI.LabelField(textRect, $"{fontName} - {value.fontSize}pt");
+
+            // マテリアル情報を含む表示
+            var displayText = $"{fontName} - {value.fontSize}pt";
+            if (value.fontSharedMaterial != null)
+                displayText += $" [{value.fontSharedMaterial.name}]";
+            else if (value.font != null && value.font.material != null)
+                // デフォルトマテリアルを使用していることを明示
+                displayText += " [Default Material]";
+            EditorGUI.LabelField(textRect, displayText);
 
             if ((value.fontStyle & FontStyles.Strikethrough) != 0)
             {

--- a/Assets/uPalette/Runtime/Core/Synchronizer/CharacterStyleTMP/TextMeshProUGUICharacterStyleTMPSynchronizer.cs
+++ b/Assets/uPalette/Runtime/Core/Synchronizer/CharacterStyleTMP/TextMeshProUGUICharacterStyleTMPSynchronizer.cs
@@ -22,7 +22,8 @@ namespace uPalette.Runtime.Core.Synchronizer.CharacterStyleTMP
                 characterSpacing = Component.characterSpacing,
                 wordSpacing = Component.wordSpacing,
                 lineSpacing = Component.lineSpacing,
-                paragraphSpacing = Component.paragraphSpacing
+                paragraphSpacing = Component.paragraphSpacing,
+                fontSharedMaterial = Component.fontSharedMaterial
             };
         }
 
@@ -43,6 +44,13 @@ namespace uPalette.Runtime.Core.Synchronizer.CharacterStyleTMP
             Component.wordSpacing = value.wordSpacing;
             Component.lineSpacing = value.lineSpacing;
             Component.paragraphSpacing = value.paragraphSpacing;
+
+            // マテリアルの設定
+            if (value.fontSharedMaterial != null)
+                Component.fontSharedMaterial = value.fontSharedMaterial;
+            else if (value.font != null)
+                // マテリアルが指定されていない場合は、フォントアセットのデフォルトマテリアルを使用
+                Component.fontSharedMaterial = value.font.material;
         }
     }
 }

--- a/Assets/uPalette/Runtime/Foundation/CharacterStyles/CharacterStyleTMP.cs
+++ b/Assets/uPalette/Runtime/Foundation/CharacterStyles/CharacterStyleTMP.cs
@@ -24,6 +24,7 @@ namespace uPalette.Runtime.Foundation.CharacterStyles
         public float wordSpacing;
         public float lineSpacing;
         public float paragraphSpacing;
+        public Material fontSharedMaterial;
 
         public static CharacterStyleTMP Default
         {
@@ -47,7 +48,8 @@ namespace uPalette.Runtime.Foundation.CharacterStyles
                     characterSpacing = 0.0f,
                     wordSpacing = 0.0f,
                     lineSpacing = 0.0f,
-                    paragraphSpacing = 0.0f
+                    paragraphSpacing = 0.0f,
+                    fontSharedMaterial = null
                 };
             }
         }

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ You can also drag elements to reorder them.
 ### Apply Entry
 To apply the color and character style you created to components, select the target GameObject and press the Apply button for the target entry. The names of applicable components and properties will then be listed, and you can select the one you want to apply.
 
+When multiple Synchronizers are implemented for the same component and property, the menu will display each Synchronizer name, allowing you to choose which Synchronizer to use.
+
 <p align="center">
   <img width="70%" src="https://user-images.githubusercontent.com/47441314/157679154-0e1aa71a-27f4-49c4-9c28-9eca8080f96d.gif" alt="Apply Entry">
 </p>
@@ -449,6 +451,40 @@ public sealed class GraphicColorSynchronizer : GradientSynchronizer<SampleGradie
 }
 ```
 
+It's also possible to implement multiple Synchronizers for the same component and property.  
+For example, you can create a custom Synchronizer that provides a different synchronization method than the standard GraphicColorSynchronizer for the existing Image component.
+
+```csharp
+[DisallowMultipleComponent]
+[RequireComponent(typeof(Image))]
+[ColorSynchronizer(typeof(Image), "Color")]
+public sealed class CustomImageColorSynchronizer : ColorSynchronizer<Image>
+{
+    [SerializeField]
+    private bool _syncAlpha = true;
+
+    protected override Color GetValue()
+    {
+        return Component.color;
+    }
+
+    protected override void SetValue(Color value)
+    {
+        if (!_syncAlpha)
+        {
+            value.a = Component.color.a;
+        }
+        Component.color = value;
+    }
+}
+```
+
+In this case, the Palette Editor's Apply menu will display as follows:
+- When there's only one Synchronizer: "Image Color"
+- When there are multiple Synchronizers: "Image Color/Graphic Color Synchronizer" and "Image Color/Custom Image Color Synchronizer"
+
+This allows you to choose different synchronization methods for the same property, enabling more flexible implementations.
+
 ### Configure behavior when an entry is not found
 
 When a target Entry is not found, you may want to output error logs, or you may want to ignore it. You can configure the behavior when an Entry is not found by `Project Settings > uPalette > Missing Entry Error`.
@@ -483,7 +519,7 @@ The Synchronizer implemented in uPalette is as follows.
 | Color | TMPro.TMP_InputField | caretColor |
 | Color | TMPro.TMP_InputField | selectionColor |
 | CharacterStyle | UnityEngine.UI.Text | font / fontStyle / fontSize / lineSpacing |
-| CharacterStyleTMP | TMPro.TextMeshProUGUI | font / fontStyle / fontSize / enableAutoSizing / characterSpacing / wordSpacing / lineSpacing / paragraphSpacing |
+| CharacterStyleTMP | TMPro.TextMeshProUGUI | font / fontStyle / fontSize / enableAutoSizing / characterSpacing / wordSpacing / lineSpacing / paragraphSpacing / fontSharedMaterial |
 
 ## Technical details
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -156,6 +156,8 @@ Palette Editorの右上にある「+」ボタンを押下することで、エ�
 作成した色や文字スタイルをコンポーネントに反映するには、対象のGameObjectを選択した状態で対象のエントリのApplyボタンを押下します。  
 すると適用可能なコンポーネントとプロパティの名前がリストアップされるので、適用したいものを選択します。
 
+同一のコンポーネント・プロパティに対して複数のSynchronizerが実装されている場合、メニューではそれぞれのSynchronizer名が表示され、どのSynchronizerを使用するか選択できます。
+
 <p align="center">
   <img width="70%" src="https://user-images.githubusercontent.com/47441314/157679154-0e1aa71a-27f4-49c4-9c28-9eca8080f96d.gif" alt="Apply Entry">
 </p>
@@ -478,6 +480,40 @@ public sealed class GraphicColorSynchronizer : GradientSynchronizer<SampleGradie
 }
 ```
 
+同一のコンポーネント・プロパティに対して複数のSynchronizerを実装することも可能です。  
+例えば、既存のImageコンポーネントに対して、標準のGraphicColorSynchronizerとは異なる同期方法を提供するカスタムSynchronizerを作成できます。
+
+```csharp
+[DisallowMultipleComponent]
+[RequireComponent(typeof(Image))]
+[ColorSynchronizer(typeof(Image), "Color")]
+public sealed class CustomImageColorSynchronizer : ColorSynchronizer<Image>
+{
+    [SerializeField]
+    private bool _syncAlpha = true;
+
+    protected override Color GetValue()
+    {
+        return Component.color;
+    }
+
+    protected override void SetValue(Color value)
+    {
+        if (!_syncAlpha)
+        {
+            value.a = Component.color.a;
+        }
+        Component.color = value;
+    }
+}
+```
+
+この場合、Palette EditorのApplyメニューでは以下のように表示されます。
+- Synchronizerが1つの場合：「Image Color」
+- 複数のSynchronizerがある場合：「Image Color/Graphic Color Synchronizer」と「Image Color/Custom Image Color Synchronizer」
+
+これにより、同じプロパティに対して異なる同期方法を選択できるようになり、より柔軟な実装が可能になります。
+
 ### エントリが見つからなかった時の挙動を設定する
 対象のエントリが見つからなかった場合、エラーログを出したい場合もあれば、それを無視したい場合もあるでしょう。  
 `Project Settings > uPalette > Missing Entry Error`から、エントリが見つからなかった時の挙動を設定できます。
@@ -512,7 +548,7 @@ uPaletteに標準で実装されているSynchronizerは以下の通りです。
 | Color | TMPro.TMP_InputField | caretColor |
 | Color | TMPro.TMP_InputField | selectionColor |
 | CharacterStyle | UnityEngine.UI.Text | font / fontStyle / fontSize / lineSpacing |
-| CharacterStyleTMP | TMPro.TextMeshProUGUI | font / fontStyle / fontSize / enableAutoSizing / characterSpacing / wordSpacing / lineSpacing / paragraphSpacing |
+| CharacterStyleTMP | TMPro.TextMeshProUGUI | font / fontStyle / fontSize / enableAutoSizing / characterSpacing / wordSpacing / lineSpacing / paragraphSpacing / fontSharedMaterial |
 
 ## 技術的詳細
 


### PR DESCRIPTION
PaletteEditorでCharacterStyleのTheme切り替え時に、フォントマテリアルも一緒に切り替わるように実装しました。

変更内容：
- CharacterStyleTMP構造体にfontSharedMaterialプロパティを追加
- TextMeshProUGUICharacterStyleTMPSynchronizerでマテリアルの同期処理を実装
- エディターUIでマテリアル選択フィールドを追加し、未設定時は「(Default)」と表示
- プレビュー表示にマテリアル情報を追加
- 既存データとの互換性を保持（nullの場合はフォントアセットのデフォルトマテリアルを使用）