### PR TITLE
fix: resolve TreeView deprecation in Unity 6.2+

### DIFF
--- a/Assets/uPalette/Editor/Core/PaletteEditor/CharacterStylePaletteEditorTreeView.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/CharacterStylePaletteEditorTreeView.cs
@@ -2,6 +2,9 @@
 using UnityEngine;
 using uPalette.Editor.Foundation.CharacterStyles;
 using uPalette.Runtime.Foundation.CharacterStyles;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/CharacterStylePaletteEditorWindowContentsView.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/CharacterStylePaletteEditorWindowContentsView.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using UnityEditor.IMGUI.Controls;
 using uPalette.Runtime.Foundation.CharacterStyles;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/CharacterStyleTMPPaletteEditorTreeView.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/CharacterStyleTMPPaletteEditorTreeView.cs
@@ -2,6 +2,9 @@
 using UnityEngine;
 using uPalette.Editor.Foundation.CharacterStyles;
 using uPalette.Runtime.Foundation.CharacterStyles;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/CharacterStyleTMPPaletteEditorWindowContentsView.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/CharacterStyleTMPPaletteEditorWindowContentsView.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using UnityEditor.IMGUI.Controls;
 using uPalette.Runtime.Foundation.CharacterStyles;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/ColorPaletteEditorTreeView.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/ColorPaletteEditorTreeView.cs
@@ -1,6 +1,9 @@
 ﻿using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/ColorPaletteEditorWindowContentsView.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/ColorPaletteEditorWindowContentsView.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/GradientPaletteEditorTreeView.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/GradientPaletteEditorTreeView.cs
@@ -1,6 +1,9 @@
 ﻿using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/GradientPaletteEditorWindowContentsView.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/GradientPaletteEditorWindowContentsView.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorTreeView.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorTreeView.cs
@@ -7,6 +7,10 @@ using UnityEngine;
 using uPalette.Editor.Core.Shared;
 using uPalette.Editor.Foundation.EasyTreeView;
 using uPalette.Runtime.Foundation.TinyRx;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorTreeViewEntryItem.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorTreeViewEntryItem.cs
@@ -4,6 +4,9 @@ using UnityEditor.IMGUI.Controls;
 using uPalette.Runtime.Foundation.TinyRx;
 using uPalette.Runtime.Foundation.TinyRx.ObservableCollection;
 using uPalette.Runtime.Foundation.TinyRx.ObservableProperty;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorTreeViewExtensions.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorTreeViewExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using UnityEditor.IMGUI.Controls;
 using uPalette.Runtime.Foundation.TinyRx;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorTreeViewFolderItem.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorTreeViewFolderItem.cs
@@ -1,4 +1,7 @@
 using UnityEditor.IMGUI.Controls;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorWindowContentsView.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorWindowContentsView.cs
@@ -4,6 +4,9 @@ using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 using uPalette.Editor.Foundation.EasyTreeView;
 using uPalette.Runtime.Foundation.TinyRx;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorWindowContentsViewController.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorWindowContentsViewController.cs
@@ -11,6 +11,9 @@ using uPalette.Runtime.Core.Synchronizer;
 using uPalette.Runtime.Foundation.TinyRx;
 using uPalette.Runtime.Foundation.TinyRx.ObservableProperty;
 using Object = UnityEngine.Object;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
 
 namespace uPalette.Editor.Core.PaletteEditor
 {

--- a/Assets/uPalette/Editor/Core/ThemeEditor/ThemeEditorTreeView.cs
+++ b/Assets/uPalette/Editor/Core/ThemeEditor/ThemeEditorTreeView.cs
@@ -6,6 +6,10 @@ using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 using uPalette.Editor.Foundation.EasyTreeView;
 using uPalette.Runtime.Foundation.TinyRx;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.ThemeEditor
 {

--- a/Assets/uPalette/Editor/Core/ThemeEditor/ThemeEditorTreeViewExtensions.cs
+++ b/Assets/uPalette/Editor/Core/ThemeEditor/ThemeEditorTreeViewExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using UnityEditor.IMGUI.Controls;
 using uPalette.Runtime.Foundation.TinyRx;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
 
 namespace uPalette.Editor.Core.ThemeEditor
 {

--- a/Assets/uPalette/Editor/Core/ThemeEditor/ThemeEditorTreeViewItem.cs
+++ b/Assets/uPalette/Editor/Core/ThemeEditor/ThemeEditorTreeViewItem.cs
@@ -1,6 +1,9 @@
 ﻿using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 using uPalette.Runtime.Foundation.TinyRx.ObservableProperty;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
 
 namespace uPalette.Editor.Core.ThemeEditor
 {

--- a/Assets/uPalette/Editor/Core/ThemeEditor/ThemeEditorWindowContentsView.cs
+++ b/Assets/uPalette/Editor/Core/ThemeEditor/ThemeEditorWindowContentsView.cs
@@ -4,6 +4,9 @@ using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 using uPalette.Editor.Foundation.EasyTreeView;
 using uPalette.Runtime.Foundation.TinyRx;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Core.ThemeEditor
 {

--- a/Assets/uPalette/Editor/Core/ThemeEditor/ThemeEditorWindowContentsViewController.cs
+++ b/Assets/uPalette/Editor/Core/ThemeEditor/ThemeEditorWindowContentsViewController.cs
@@ -6,6 +6,9 @@ using uPalette.Editor.Core.Shared;
 using uPalette.Editor.Foundation;
 using uPalette.Runtime.Core.Model;
 using uPalette.Runtime.Foundation.TinyRx;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
 
 namespace uPalette.Editor.Core.ThemeEditor
 {

--- a/Assets/uPalette/Editor/Foundation/EasyTreeView/TreeViewBase.cs
+++ b/Assets/uPalette/Editor/Foundation/EasyTreeView/TreeViewBase.cs
@@ -4,6 +4,11 @@ using System.Linq;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_2_OR_NEWER
+using TreeView = UnityEditor.IMGUI.Controls.TreeView<int>;
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace uPalette.Editor.Foundation.EasyTreeView
 {

--- a/Assets/uPalette/Editor/Foundation/TreeViewBaseExtensions.cs
+++ b/Assets/uPalette/Editor/Foundation/TreeViewBaseExtensions.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using UnityEditor.IMGUI.Controls;
 using uPalette.Editor.Foundation.EasyTreeView;
 using uPalette.Runtime.Foundation.TinyRx;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
 
 namespace uPalette.Editor.Foundation
 {


### PR DESCRIPTION
## Description

Unity 6 (6000.2) has deprecated the non-generic `TreeView`, `TreeViewItem`, and `TreeViewState` classes in `UnityEditor.IMGUI.Controls`.

*  **Unity 6000.2+**: Triggers obsolete warnings (**CS0618**).
*  **Unity 6000.5+**: Triggers obsolete compiler errors (**CS0619**).

### Solution

Introduced type aliasing for these classes to their generic counterparts (`TreeView<int>`, etc.) using the `#if UNITY_6000_2_OR_NEWER` preprocessor directive.

* **Removes deprecation warnings** in Unity 6000.2 and later.
* **Fixes build errors** in Unity 6000.5 and later.