### PR TITLE
Resolve the object search deprecation warning in Unity 6

### DIFF
--- a/Assets/uPalette/Editor/Core/Shared/FindAppliedGameObjectService.cs
+++ b/Assets/uPalette/Editor/Core/Shared/FindAppliedGameObjectService.cs
@@ -10,7 +10,11 @@ namespace uPalette.Editor.Core.Shared
         public GameObject[] Execute(params string[] entryIds)
         {
             var result = new List<GameObject>();
+#if UNITY_2022_2_OR_NEWER
+            var synchronizers = Object.FindObjectsByType<ColorSynchronizer>(FindObjectsSortMode.InstanceID);
+#else
             var synchronizers = Object.FindObjectsOfType<ColorSynchronizer>();
+#endif
             foreach (var synchronizer in synchronizers)
             {
                 if (result.Contains(synchronizer.gameObject))


### PR DESCRIPTION

## Overview

- `Object.FindObjectsOfType` emits a deprecation warning when uPalette is compiled with Unity 6
- Use the current object search API where available while retaining compatibility with older supported Unity versions
- Preserve the existing InstanceID ordering so the search behavior remains unchanged

## Key changes

- Select the object search API based on the Unity version
  - Use `FindObjectsByType` with InstanceID sorting on Unity 2022.2 or newer
  - Continue using `FindObjectsOfType` on earlier Unity versions

## Verification

- Confirmed successful compilation with Unity 6000.2.0f1
- Confirmed no C# compilation warnings or errors