### PR TITLE
fix: align palette and Name Enums ordering

### DIFF
--- a/Assets/uPalette/Editor/AssemblyInfo.cs
+++ b/Assets/uPalette/Editor/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("uPalette.Editor.Tests")]

--- a/Assets/uPalette/Editor/AssemblyInfo.cs.meta
+++ b/Assets/uPalette/Editor/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e32cc903f70c34b9e9470b763be4fb09

--- a/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorTreeView.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorTreeView.cs
@@ -20,6 +20,7 @@ namespace uPalette.Editor.Core.PaletteEditor
 
         private readonly Dictionary<int, string> _columnIndexToThemeIdMap = new Dictionary<int, string>();
         private readonly Dictionary<string, int> _entryIdToItemIdMap = new Dictionary<string, int>();
+        private readonly List<string> _flatEntryOrder = new List<string>();
         private readonly Dictionary<string, int> _folderPathToItemIdMap = new Dictionary<string, int>();
 
         private readonly Subject<(PaletteEditorTreeViewEntryItem<T> item, int newIndex)> _itemIndexChangedSubject =
@@ -83,6 +84,7 @@ namespace uPalette.Editor.Core.PaletteEditor
                 id = _currentItemId++
             };
             _entryIdToItemIdMap.Add(entryId, entryItem.id);
+            _flatEntryOrder.Add(entryId);
             AddItemAndSetParent(entryItem, -1);
             SetHierarchy(entryItem.id);
             return entryItem;
@@ -204,8 +206,8 @@ namespace uPalette.Editor.Core.PaletteEditor
             _folderPathToItemIdMap.Clear();
 
             // Build hierarchy
-            foreach (var entryItemId in _entryIdToItemIdMap.Values)
-                SetHierarchy(entryItemId);
+            foreach (var entryId in _flatEntryOrder)
+                SetHierarchy(_entryIdToItemIdMap[entryId]);
 
             if (FolderMode)
                 OrderItemsByName(RootItem, true);
@@ -219,8 +221,20 @@ namespace uPalette.Editor.Core.PaletteEditor
             var id = _entryIdToItemIdMap[entryId];
             var item = GetItem(id);
             _entryIdToItemIdMap.Remove(entryId);
+            _flatEntryOrder.Remove(entryId);
             RemoveItem(id, invokeCallback);
             RemoveParentItemsIfEmpty(item);
+        }
+
+        public new void ClearItems(bool invokeCallback = true)
+        {
+            foreach (var entryId in _flatEntryOrder.ToArray())
+                RemoveItem(entryId, invokeCallback);
+
+            base.ClearItems(invokeCallback);
+            _entryIdToItemIdMap.Clear();
+            _flatEntryOrder.Clear();
+            _folderPathToItemIdMap.Clear();
         }
 
         private void RemoveParentItemsIfEmpty(TreeViewItem item)
@@ -398,7 +412,7 @@ namespace uPalette.Editor.Core.PaletteEditor
                             var itemIndex = RootItem.children.IndexOf(item);
                             if (itemIndex < afterIndex) afterIndex--;
 
-                            SetItemIndex(item, afterIndex, true);
+                            SetFlatEntryIndex(item, afterIndex, true);
                             afterIndex++;
                         }
 
@@ -417,20 +431,32 @@ namespace uPalette.Editor.Core.PaletteEditor
             return DragAndDropVisualMode.Move;
         }
 
-        /// <summary>
-        ///     Sort items by specifying index
-        /// </summary>
-        /// <param name="entryItem"></param>
-        /// <param name="index"></param>
-        /// <param name="notify"></param>
-        public void SetItemIndex(PaletteEditorTreeViewEntryItem<T> entryItem, int index, bool notify)
+        public void SetFlatEntryIndex(PaletteEditorTreeViewEntryItem<T> entryItem, int index, bool notify)
         {
-            var children = RootItem.children;
-            var itemIndex = RootItem.children.IndexOf(entryItem);
-            children.RemoveAt(itemIndex);
-            children.Insert(index, entryItem);
+            var entryOrderIndex = _flatEntryOrder.IndexOf(entryItem.EntryId);
+            _flatEntryOrder.RemoveAt(entryOrderIndex);
+            _flatEntryOrder.Insert(index, entryItem.EntryId);
+
+            // Folder mode has its own name-based hierarchy, but the saved flat order must still follow Undo/Redo.
+            if (!FolderMode)
+                MoveFlatEntryItem(entryItem, index);
+
             if (notify)
                 _itemIndexChangedSubject.OnNext((entryItem, index));
+        }
+
+        public void RestoreFlatEntryPosition(PaletteEditorTreeViewEntryItem<T> entryItem)
+        {
+            var index = _flatEntryOrder.IndexOf(entryItem.EntryId);
+            MoveFlatEntryItem(entryItem, index);
+        }
+
+        private void MoveFlatEntryItem(PaletteEditorTreeViewEntryItem<T> entryItem, int index)
+        {
+            var children = RootItem.children;
+            var itemIndex = children.IndexOf(entryItem);
+            children.RemoveAt(itemIndex);
+            children.Insert(index, entryItem);
         }
 
         /// <summary>
@@ -441,7 +467,7 @@ namespace uPalette.Editor.Core.PaletteEditor
         {
             var children = item.parent.children;
             var orderedChildren = children
-                .OrderBy(x => x.displayName, Comparer<string>.Create(EditorUtility.NaturalCompare))
+                .OrderBy(x => x, Comparer<TreeViewItem>.Create(CompareItemsByName))
                 .ToArray();
             var index = Array.IndexOf(orderedChildren, item);
 
@@ -462,7 +488,7 @@ namespace uPalette.Editor.Core.PaletteEditor
 
             var children = parent.children;
             var orderedChildren = children
-                .OrderBy(x => x.displayName, Comparer<string>.Create(EditorUtility.NaturalCompare))
+                .OrderBy(x => x, Comparer<TreeViewItem>.Create(CompareItemsByName))
                 .ToArray();
 
             children.Clear();
@@ -472,6 +498,15 @@ namespace uPalette.Editor.Core.PaletteEditor
                 if (recursive)
                     OrderItemsByName(child, true);
             }
+        }
+
+        private static int CompareItemsByName(TreeViewItem leftItem, TreeViewItem rightItem)
+        {
+            return PaletteEntryOrdering.CompareSiblingNames(
+                leftItem.displayName,
+                leftItem is PaletteEditorTreeViewFolderItem,
+                rightItem.displayName,
+                rightItem is PaletteEditorTreeViewFolderItem);
         }
 
         private void SetupColumnStates()

--- a/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorWindowContentsViewController.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorWindowContentsViewController.cs
@@ -157,14 +157,16 @@ namespace uPalette.Editor.Core.PaletteEditor
         {
             var oldIndex = _palette.GetEntryOrder(entryItem.EntryId);
             _editService.Edit($"Change {typeof(T).Name} Entry Index {entryItem.EntryId}",
-                () => _palette.SetEntryOrder(entryItem.EntryId, index),
-                () =>
-                {
-                    _palette.SetEntryOrder(entryItem.EntryId, oldIndex);
-                    _view.TreeView.SetItemIndex(entryItem, oldIndex, false);
-                    _view.TreeView.Reload();
-                },
+                () => SetFlatEntryIndex(entryItem, index),
+                () => SetFlatEntryIndex(entryItem, oldIndex),
                 markAsIdOrNameDirty: true);
+        }
+
+        private void SetFlatEntryIndex(PaletteEditorTreeViewEntryItem<T> entryItem, int index)
+        {
+            _palette.SetEntryOrder(entryItem.EntryId, index);
+            _view.TreeView.SetFlatEntryIndex(entryItem, index, false);
+            _view.TreeView.Reload();
         }
 
         private void OnRightClickRemoveMenuClicked()

--- a/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorWindowContentsViewPresenter.cs
+++ b/Assets/uPalette/Editor/Core/PaletteEditor/PaletteEditorWindowContentsViewPresenter.cs
@@ -62,7 +62,8 @@ namespace uPalette.Editor.Core.PaletteEditor
                 AddTreeViewItem(entry, index, false);
             }
 
-            _view.TreeView.OrderItemsByName(_view.TreeView.RootItem, true);
+            if (_view.TreeView.FolderMode)
+                _view.TreeView.OrderItemsByName(_view.TreeView.RootItem, true);
 
             view.TreeView.Reload();
         }
@@ -119,7 +120,7 @@ namespace uPalette.Editor.Core.PaletteEditor
                 if (treeView.FolderMode)
                     treeView.SetItemIndexByName(item);
                 else
-                    treeView.SetItemIndex(item, index, false);
+                    treeView.SetFlatEntryIndex(item, index, false);
             }
 
             // Observe entry.
@@ -163,7 +164,7 @@ namespace uPalette.Editor.Core.PaletteEditor
                     if (treeView.FolderMode)
                         treeView.SetItemIndexByName(item);
                     else
-                        treeView.SetItemIndex(item, index, false);
+                        treeView.RestoreFlatEntryPosition(item);
                     treeView.Reload();
                 })
                 .DisposeWith(disposable);

--- a/Assets/uPalette/Editor/Core/Shared/EditPaletteStoreService.cs
+++ b/Assets/uPalette/Editor/Core/Shared/EditPaletteStoreService.cs
@@ -20,8 +20,14 @@ namespace uPalette.Editor.Core.Shared
 
         public bool IsIdOrNameDirty
         {
-            get => EditorPrefs.GetBool(EditorPrefsKey.IsIdOrNameDirtyPrefsKey, false);
-            set => EditorPrefs.SetBool(EditorPrefsKey.IsIdOrNameDirtyPrefsKey, value);
+            get => _generateNameEnumsFileService.IsDirty;
+            set
+            {
+                if (value)
+                    _generateNameEnumsFileService.MarkDirty();
+                else
+                    _generateNameEnumsFileService.ClearDirty();
+            }
         }
 
         public EditPaletteStoreService(PaletteStore paletteStore,
@@ -103,21 +109,7 @@ namespace uPalette.Editor.Core.Shared
 
         public void GenerateNameEnumsFileIfNeeded()
         {
-            if (!IsIdOrNameDirty)
-                return;
-            
-            EditorUtility.DisplayProgressBar("Processing", "Generating Name Enum File...", 0.0f);
-            try
-            {
-                _generateNameEnumsFileService.Run();
-
-            }
-            finally
-            {
-                EditorUtility.DisplayProgressBar("Processing", "Generating Name Enum File...", 1.0f);
-                EditorUtility.ClearProgressBar();
-            }
-            ClearIdOrNameDirty();
+            _generateNameEnumsFileService.RunIfNeeded();
         }
 
         public void MarkAsDirty()
@@ -127,7 +119,7 @@ namespace uPalette.Editor.Core.Shared
 
         public void MarkAsIdOrNameDirty()
         {
-            IsIdOrNameDirty = true;
+            _generateNameEnumsFileService.MarkDirty();
         }
 
         public void Undo()
@@ -147,7 +139,7 @@ namespace uPalette.Editor.Core.Shared
 
         public void ClearIdOrNameDirty()
         {
-            IsIdOrNameDirty = false;
+            _generateNameEnumsFileService.ClearDirty();
         }
 
         private void OnUpdate()

--- a/Assets/uPalette/Editor/Core/Shared/GenerateNameEnumsFileService.cs
+++ b/Assets/uPalette/Editor/Core/Shared/GenerateNameEnumsFileService.cs
@@ -23,6 +23,40 @@ namespace uPalette.Editor.Core.Shared
                 : AssetDatabase.GetAssetPath(settings.NameEnumsFolder);
             var filePath = $"{folderPath}/NameEnums.cs";
             RunInternal(filePath);
+            ClearDirty();
+        }
+
+        internal void RunIfNeeded()
+        {
+            if (!IsDirty)
+                return;
+
+            EditorUtility.DisplayProgressBar("Processing", "Generating Name Enum File...", 0.0f);
+            try
+            {
+                Run();
+            }
+            finally
+            {
+                EditorUtility.DisplayProgressBar("Processing", "Generating Name Enum File...", 1.0f);
+                EditorUtility.ClearProgressBar();
+            }
+        }
+
+        internal void MarkDirty()
+        {
+            IsDirty = true;
+        }
+
+        internal void ClearDirty()
+        {
+            IsDirty = false;
+        }
+
+        internal bool IsDirty
+        {
+            get => EditorPrefs.GetBool(EditorPrefsKey.IsIdOrNameDirtyPrefsKey, false);
+            set => EditorPrefs.SetBool(EditorPrefsKey.IsIdOrNameDirtyPrefsKey, value);
         }
 
         private void RunInternal(string filePath)
@@ -67,15 +101,39 @@ namespace uPalette.Editor.Core.Shared
 
         private static NameEnumsTemplateInput.PaletteData CreatePaletteData<T>(string typeName, Palette<T> palette)
         {
-            var paletteData = new NameEnumsTemplateInput.PaletteData(typeName);
             var settings = UPaletteProjectSettings.instance;
             var folderDelimiter = settings.FolderDelimiter;
             var containsFolderNameToNameEnums = settings.ContainsFolderNameToNameEnums;
 
+            return CreatePaletteData(
+                typeName,
+                palette,
+                folderDelimiter,
+                containsFolderNameToNameEnums,
+                settings.UseFolderViewInPaletteEditor);
+        }
+
+        internal static NameEnumsTemplateInput.PaletteData CreatePaletteData<T>(
+            string typeName,
+            Palette<T> palette,
+            char folderDelimiter,
+            bool containsFolderNameToNameEnums,
+            bool useFolderViewInPaletteEditor
+        )
+        {
+            var paletteData = new NameEnumsTemplateInput.PaletteData(typeName);
+
             foreach (var idAndName in palette.GetThemeIdAndNames(folderDelimiter, containsFolderNameToNameEnums))
                 paletteData.AddThemeInfo(idAndName.name, idAndName.id);
 
-            foreach (var idAndName in palette.GetEntryIdAndNames(folderDelimiter, containsFolderNameToNameEnums))
+            var entries = PaletteEntryOrdering.GetOrderedEntries(
+                palette,
+                useFolderViewInPaletteEditor,
+                folderDelimiter);
+            foreach (var idAndName in palette.GetEntryIdAndNames(
+                         entries,
+                         folderDelimiter,
+                         containsFolderNameToNameEnums))
                 paletteData.AddEntryInfo(idAndName.name, idAndName.id);
 
             return paletteData;

--- a/Assets/uPalette/Editor/Core/Shared/PaletteEntryOrdering.cs
+++ b/Assets/uPalette/Editor/Core/Shared/PaletteEntryOrdering.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using uPalette.Runtime.Core.Model;
+
+namespace uPalette.Editor.Core.Shared
+{
+    internal static class PaletteEntryOrdering
+    {
+        public static IEnumerable<Entry<T>> GetOrderedEntries<T>(
+            Palette<T> palette,
+            bool folderMode,
+            char folderDelimiter
+        )
+        {
+            var entries = palette.Entries.Values.OrderBy(entry => palette.GetEntryOrder(entry.Id));
+            if (!folderMode)
+                return entries;
+
+            return entries.OrderBy(entry => entry.Name.Value, new FolderPathComparer(folderDelimiter));
+        }
+
+        public static int CompareSiblingNames(
+            string leftName,
+            bool leftIsFolder,
+            string rightName,
+            bool rightIsFolder
+        )
+        {
+            var nameComparison = CompareNames(leftName, rightName);
+            if (nameComparison != 0 || leftIsFolder == rightIsFolder)
+                return nameComparison;
+
+            return leftIsFolder ? -1 : 1;
+        }
+
+        private static int CompareNames(string leftName, string rightName)
+        {
+            var naturalComparison = EditorUtility.NaturalCompare(leftName, rightName);
+            if (naturalComparison != 0)
+                return naturalComparison;
+
+            return string.Compare(leftName, rightName, StringComparison.Ordinal);
+        }
+
+        private sealed class FolderPathComparer : IComparer<string>
+        {
+            private readonly char _folderDelimiter;
+
+            public FolderPathComparer(char folderDelimiter)
+            {
+                _folderDelimiter = folderDelimiter;
+            }
+
+            public int Compare(string leftPath, string rightPath)
+            {
+                var leftNames = leftPath.Split(_folderDelimiter);
+                var rightNames = rightPath.Split(_folderDelimiter);
+                var sharedDepth = Math.Min(leftNames.Length, rightNames.Length);
+
+                for (var i = 0; i < sharedDepth; i++)
+                {
+                    var nameComparison = CompareNames(leftNames[i], rightNames[i]);
+                    if (nameComparison != 0)
+                        return nameComparison;
+                }
+
+                if (leftNames.Length == rightNames.Length)
+                    return 0;
+
+                // A folder and an entry can have the same display name. Placing the folder first gives
+                // the hierarchical TreeView and the flattened Name Enums a deterministic common order.
+                return leftNames.Length > rightNames.Length ? -1 : 1;
+            }
+        }
+    }
+}

--- a/Assets/uPalette/Editor/Core/Shared/PaletteEntryOrdering.cs.meta
+++ b/Assets/uPalette/Editor/Core/Shared/PaletteEntryOrdering.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 76c388db732d74bbb8b43d35e06afb4d

--- a/Assets/uPalette/Editor/Core/Shared/UPaletteProjectSettingsProvider.cs
+++ b/Assets/uPalette/Editor/Core/Shared/UPaletteProjectSettingsProvider.cs
@@ -10,6 +10,9 @@ namespace uPalette.Editor.Core.Shared
 {
     public sealed class UPaletteProjectSettingsProvider : SettingsProvider
     {
+        private static bool _isNameEnumsGenerationScheduled;
+        private static PaletteStore _scheduledGenerationStore;
+
         public UPaletteProjectSettingsProvider(string path, SettingsScope scopes, IEnumerable<string> keywords = null)
             : base(path, scopes, keywords)
         {
@@ -69,14 +72,13 @@ namespace uPalette.Editor.Core.Shared
                             projectSettings.NameEnumsFolder,
                             typeof(DefaultAsset), false);
 
-                    if (ccs.changed && projectSettings.NameEnumsFileGenerateMode ==
-                        NameEnumsFileGenerateMode.WhenWindowLosesFocus)
-                        EditorPrefs.SetBool(EditorPrefsKey.IsIdOrNameDirtyPrefsKey, true);
-                }
+                    projectSettings.UseFolderViewInPaletteEditor = EditorGUILayout.Toggle(
+                        "Use Folder View in Palette Editor",
+                        projectSettings.UseFolderViewInPaletteEditor);
 
-                projectSettings.UseFolderViewInPaletteEditor = EditorGUILayout.Toggle(
-                    "Use Folder View in Palette Editor",
-                    projectSettings.UseFolderViewInPaletteEditor);
+                    if (ccs.changed)
+                        RequestNameEnumsGeneration(store, projectSettings.NameEnumsFileGenerateMode);
+                }
 
                 projectSettings.AutomaticRuntimeDataLoading = EditorGUILayout.Toggle("Automatic Runtime Data Loading",
                     projectSettings.AutomaticRuntimeDataLoading);
@@ -115,6 +117,41 @@ namespace uPalette.Editor.Core.Shared
                     EditorUtility.SetDirty(store);
                 }
             }
+        }
+
+        private static void RequestNameEnumsGeneration(
+            PaletteStore store,
+            NameEnumsFileGenerateMode generateMode
+        )
+        {
+            var generationService = new GenerateNameEnumsFileService(store);
+            generationService.MarkDirty();
+
+            if (generateMode != NameEnumsFileGenerateMode.WhenWindowLosesFocus)
+                return;
+
+            _scheduledGenerationStore = store;
+            if (_isNameEnumsGenerationScheduled)
+                return;
+
+            _isNameEnumsGenerationScheduled = true;
+            EditorApplication.delayCall += GenerateScheduledNameEnums;
+        }
+
+        private static void GenerateScheduledNameEnums()
+        {
+            _isNameEnumsGenerationScheduled = false;
+            var store = _scheduledGenerationStore;
+            _scheduledGenerationStore = null;
+
+            if (UPaletteProjectSettings.instance.NameEnumsFileGenerateMode !=
+                NameEnumsFileGenerateMode.WhenWindowLosesFocus)
+                return;
+
+            if (store == null)
+                return;
+
+            new GenerateNameEnumsFileService(store).RunIfNeeded();
         }
 
         private sealed class GUIScope : GUI.Scope

--- a/Assets/uPalette/Runtime/Core/Model/Palette.cs
+++ b/Assets/uPalette/Runtime/Core/Model/Palette.cs
@@ -412,9 +412,20 @@ namespace uPalette.Runtime.Core.Model
             bool nicifyNames = true
         )
         {
+            var entries = _entries.Values.OrderBy(x => GetEntryOrder(x.Id));
+            return GetEntryIdAndNames(entries, folderDelimiter, containsFolderName, nicifyNames);
+        }
+
+        internal IEnumerable<(string id, string name)> GetEntryIdAndNames(
+            IEnumerable<Entry<T>> entries,
+            char folderDelimiter,
+            bool containsFolderName,
+            bool nicifyNames = true
+        )
+        {
             var processedNames = new List<string>();
 
-            foreach (var entry in _entries.Values.OrderBy(x => GetEntryOrder(x.Id)))
+            foreach (var entry in entries)
             {
                 var name = entry.Name.Value;
 

--- a/Assets/uPalette/Tests/Editor.meta
+++ b/Assets/uPalette/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4858d160d274b462992b17c99105bbb6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/uPalette/Tests/Editor/PaletteEntryOrderingTest.cs
+++ b/Assets/uPalette/Tests/Editor/PaletteEntryOrderingTest.cs
@@ -1,0 +1,230 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor.IMGUI.Controls;
+using UnityEngine;
+using uPalette.Editor.Core.PaletteEditor;
+using uPalette.Editor.Core.Shared;
+using uPalette.Runtime.Core;
+using uPalette.Runtime.Core.Model;
+
+namespace uPalette.Tests.Editor
+{
+    public sealed class PaletteEntryOrderingTest
+    {
+        [Test]
+        public void GetOrderedEntries_FolderHierarchyIsComparedBeforeFullEntryPath()
+        {
+            var palette = new ColorPalette();
+
+            // フラットなエントリを、同じ接頭辞を持つフォルダ内エントリより先に保存しておく。
+            var flatEntry = palette.AddEntry();
+            flatEntry.Name.Value = "A.Thing";
+            var folderEntry = palette.AddEntry();
+            folderEntry.Name.Value = "A/Z";
+
+            // フォルダ表示と同じ階層順でエントリを取得する。
+            var orderedEntryIds = PaletteEntryOrdering.GetOrderedEntries(palette, true, '/')
+                .Select(entry => entry.Id)
+                .ToArray();
+
+            // ルートではフォルダ名のAがA.Thingより先になるため、フォルダ内エントリが先になる。
+            Assert.That(orderedEntryIds, Is.EqualTo(new[] { folderEntry.Id, flatEntry.Id }));
+        }
+
+        [Test]
+        public void SetFolderMode_WhenReturningToFlatMode_RestoresDragAndDropOrder()
+        {
+            var treeView = new ColorPaletteEditorTreeView(new TreeViewState());
+            var alphaEntry = treeView.AddItem("alpha", "Alpha", new Dictionary<string, Color>());
+            var betaEntry = treeView.AddItem("beta", "Beta", new Dictionary<string, Color>());
+
+            // フラット表示でBetaをAlphaより前へドラッグした状態にする。
+            treeView.SetFlatEntryIndex(betaEntry, 0, false);
+
+            // フォルダ表示へ切り替えて名前順にした後、フラット表示へ戻す。
+            treeView.SetFolderMode(true, false);
+            treeView.SetFolderMode(false, false);
+            var entryIds = treeView.RootItem.children
+                .Cast<PaletteEditorTreeViewEntryItem<Color>>()
+                .Select(entry => entry.EntryId)
+                .ToArray();
+
+            // フラット表示では、切り替え前のドラッグ&ドロップ順に復帰する。
+            Assert.That(entryIds, Is.EqualTo(new[] { betaEntry.EntryId, alphaEntry.EntryId }));
+        }
+
+        [Test]
+        public void SetFlatEntryIndex_InFolderMode_UpdatesOnlyTheSavedFlatOrder()
+        {
+            var treeView = new ColorPaletteEditorTreeView(new TreeViewState());
+            var alphaEntry = treeView.AddItem("alpha", "Alpha", new Dictionary<string, Color>());
+            var betaEntry = treeView.AddItem("beta", "Beta", new Dictionary<string, Color>());
+
+            // フォルダ表示中にUndoまたはRedoがフラット順をBeta、Alphaへ更新した状態にする。
+            treeView.SetFolderMode(true, false);
+            treeView.SetFlatEntryIndex(betaEntry, 0, false);
+            var folderModeEntryIds = GetEntryIds(treeView.RootItem).ToArray();
+
+            // フォルダ表示は名前順のまま維持される。
+            Assert.That(folderModeEntryIds, Is.EqualTo(new[] { alphaEntry.EntryId, betaEntry.EntryId }));
+
+            // フラット表示へ戻す。
+            treeView.SetFolderMode(false, false);
+            var flatModeEntryIds = GetEntryIds(treeView.RootItem).ToArray();
+
+            // UndoまたはRedoで更新したフラット順が表示へ反映される。
+            Assert.That(flatModeEntryIds, Is.EqualTo(new[] { betaEntry.EntryId, alphaEntry.EntryId }));
+        }
+
+        [Test]
+        public void EntryOrderRedo_InFolderMode_RestoresTheFlatOrderInTreeView()
+        {
+            var store = ScriptableObject.CreateInstance<PaletteStore>();
+            var generateService = new GenerateNameEnumsFileService(store);
+            var wasNameEnumsDirty = generateService.IsDirty;
+            var editService = new EditPaletteStoreService(store, generateService);
+            var view = new ColorPaletteEditorWindowContentsView();
+            view.Setup();
+            var palette = store.ColorPalette;
+            var alphaEntry = palette.AddEntry();
+            alphaEntry.Name.Value = "Alpha";
+            var betaEntry = palette.AddEntry();
+            betaEntry.Name.Value = "Beta";
+            var controller = new PaletteEditorWindowContentsViewController<Color>(palette, editService, view);
+            var presenter = new PaletteEditorWindowContentsViewPresenter<Color>(palette, view);
+
+            try
+            {
+                // フラット表示でBetaを先頭へ移動し、その並べ替えを履歴へ登録する。
+                var betaItem = view.TreeView.RootItem.children
+                    .Cast<PaletteEditorTreeViewEntryItem<Color>>()
+                    .Single(item => item.EntryId == betaEntry.Id);
+                view.TreeView.SetFlatEntryIndex(betaItem, 0, true);
+
+                // フォルダ表示へ切り替えた状態で、並べ替えをUndoしてからRedoする。
+                view.TreeView.SetFolderMode(true, false);
+                editService.Undo();
+                editService.Redo();
+
+                // フラット表示へ戻す。
+                view.TreeView.SetFolderMode(false, false);
+                var entryIds = GetEntryIds(view.TreeView.RootItem).ToArray();
+
+                // モデルとTreeViewの両方が、Redo後のBeta、Alphaの順になっている。
+                Assert.That(palette.GetEntryOrder(betaEntry.Id), Is.EqualTo(0));
+                Assert.That(entryIds, Is.EqualTo(new[] { betaEntry.Id, alphaEntry.Id }));
+            }
+            finally
+            {
+                controller.Dispose();
+                presenter.Dispose();
+                view.Dispose();
+                editService.ClearDirty();
+                editService.Dispose();
+
+                if (wasNameEnumsDirty)
+                    generateService.MarkDirty();
+                else
+                    generateService.ClearDirty();
+
+                Object.DestroyImmediate(store);
+            }
+        }
+
+        [Test]
+        public void FolderMode_TreeViewAndNameEnumsUseTheSameEntryOrder()
+        {
+            var palette = new ColorPalette();
+            var flatEntry = palette.AddEntry();
+            flatEntry.Name.Value = "A.Thing";
+            var folderEntry = palette.AddEntry();
+            folderEntry.Name.Value = "A/Z";
+            var treeView = new ColorPaletteEditorTreeView(new TreeViewState());
+            treeView.AddItem(flatEntry.Id, flatEntry.Name.Value, new Dictionary<string, Color>());
+            treeView.AddItem(folderEntry.Id, folderEntry.Name.Value, new Dictionary<string, Color>());
+
+            // TreeViewをフォルダ表示にし、Name Enums用データもフォルダ表示の設定で作成する。
+            treeView.SetFolderMode(true, false);
+            var treeViewEntryIds = GetEntryIds(treeView.RootItem).ToArray();
+            var paletteData = GenerateNameEnumsFileService.CreatePaletteData(
+                nameof(Color),
+                palette,
+                '/',
+                true,
+                true);
+            var nameEnumsEntryIds = paletteData.EntryInfos.Select(entry => entry.id).ToArray();
+
+            // Palette EditorとName Enumsで同じエントリ順になる。
+            Assert.That(nameEnumsEntryIds, Is.EqualTo(treeViewEntryIds));
+        }
+
+        [TestCase(false, "Z")]
+        [TestCase(true, "A_Z")]
+        public void CreatePaletteData_FolderNameOptionDoesNotChangeEntryOrder(
+            bool containsFolderName,
+            string expectedFolderEntryName
+        )
+        {
+            var palette = new ColorPalette();
+
+            // フォルダ名を含める設定にかかわらず、階層順ではAフォルダが先になるエントリを用意する。
+            var flatEntry = palette.AddEntry();
+            flatEntry.Name.Value = "A.Thing";
+            var folderEntry = palette.AddEntry();
+            folderEntry.Name.Value = "A/Z";
+
+            // フォルダ名の出力設定を指定して、Name Enums用データを作成する。
+            var paletteData = GenerateNameEnumsFileService.CreatePaletteData(
+                nameof(Color),
+                palette,
+                '/',
+                containsFolderName,
+                true);
+            var entryNames = paletteData.EntryInfos.Select(entry => entry.name).ToArray();
+
+            // enum名だけが設定に応じて変わり、エントリ順は変わらない。
+            Assert.That(entryNames, Is.EqualTo(new[] { expectedFolderEntryName, "A.Thing" }));
+        }
+
+        [Test]
+        public void CreatePaletteData_FlatModeUsesDragAndDropOrder()
+        {
+            var palette = new ColorPalette();
+            var firstEntry = palette.AddEntry();
+            firstEntry.Name.Value = "First";
+            var secondEntry = palette.AddEntry();
+            secondEntry.Name.Value = "Second";
+
+            // Palette Editorのドラッグ&ドロップに相当する保存順として、Secondを先頭へ移動する。
+            palette.SetEntryOrder(secondEntry.Id, 0);
+
+            // フォルダ表示を使わない設定で、Name Enums用データを作成する。
+            var paletteData = GenerateNameEnumsFileService.CreatePaletteData(
+                nameof(Color),
+                palette,
+                '/',
+                false,
+                false);
+            var entryIds = paletteData.EntryInfos.Select(entry => entry.id).ToArray();
+
+            // Name Enumsには、Palette Editorで指定したドラッグ&ドロップ順が使われる。
+            Assert.That(entryIds, Is.EqualTo(new[] { secondEntry.Id, firstEntry.Id }));
+        }
+
+        private static IEnumerable<string> GetEntryIds(TreeViewItem parent)
+        {
+            if (parent.children == null)
+                yield break;
+
+            foreach (var child in parent.children)
+            {
+                if (child is PaletteEditorTreeViewEntryItem<Color> entryItem)
+                    yield return entryItem.EntryId;
+
+                foreach (var entryId in GetEntryIds(child))
+                    yield return entryId;
+            }
+        }
+    }
+}

--- a/Assets/uPalette/Tests/Editor/PaletteEntryOrderingTest.cs.meta
+++ b/Assets/uPalette/Tests/Editor/PaletteEntryOrderingTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1fe455f9b42674d518e3a1e121e476b4

--- a/Assets/uPalette/Tests/Editor/uPalette.Editor.Tests.asmdef
+++ b/Assets/uPalette/Tests/Editor/uPalette.Editor.Tests.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "uPalette.Editor.Tests",
+    "references": [
+        "GUID:45481c1a5703e4b4db8cfbe8316a40db",
+        "GUID:f2b46654766a88a40bf344f29aec823f"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/uPalette/Tests/Editor/uPalette.Editor.Tests.asmdef.meta
+++ b/Assets/uPalette/Tests/Editor/uPalette.Editor.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 050fdc7f8ac1c40bd9b29894bf0cd825
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/uPalette/Tests/Runtime/PaletteTest.cs
+++ b/Assets/uPalette/Tests/Runtime/PaletteTest.cs
@@ -315,6 +315,54 @@ namespace uPalette.Tests.Runtime
         }
 
         [Test]
+        public void GetEntryIdAndNames_EntriesAreOrderedByEntryOrderWhenContainingFolderNames()
+        {
+            var palette = new ColorPalette();
+            const char folderDelimiter = '/';
+
+            // フォルダ名を含むエントリを、名前順とは異なる順序で並べる。
+            var firstEntry = palette.AddEntry();
+            firstEntry.Name.Value = "Folder/First";
+            var secondEntry = palette.AddEntry();
+            secondEntry.Name.Value = "Folder/Second";
+            var thirdEntry = palette.AddEntry();
+            thirdEntry.Name.Value = "Folder/Third";
+            palette.SetEntryOrder(thirdEntry.Id, 0);
+
+            // フォルダ名を含めて NameEnums の入力を作成する。
+            var entryNames = palette.GetEntryIdAndNames(folderDelimiter, true)
+                .Select(x => x.name)
+                .ToArray();
+
+            // enum の宣言順に、Palette Editor で指定したエントリ順を使う。
+            Assert.That(entryNames, Is.EqualTo(new[] { "Folder_Third", "Folder_First", "Folder_Second" }));
+        }
+
+        [Test]
+        public void GetEntryIdAndNames_UsesSpecifiedEntrySequenceWhenProcessingNames()
+        {
+            var palette = new ColorPalette();
+            const char folderDelimiter = '/';
+
+            // フォルダ名を含むエントリを3件用意する。
+            var thirdEntry = palette.AddEntry();
+            thirdEntry.Name.Value = "Folder/Third";
+            var firstEntry = palette.AddEntry();
+            firstEntry.Name.Value = "Folder/First";
+            var secondEntry = palette.AddEntry();
+            secondEntry.Name.Value = "Folder/Second";
+
+            // Paletteの保存順とは異なる順序を明示的に指定して、Name Enumsの入力を作成する。
+            var entries = new[] { firstEntry, secondEntry, thirdEntry };
+            var entryNames = palette.GetEntryIdAndNames(entries, folderDelimiter, true)
+                .Select(x => x.name)
+                .ToArray();
+
+            // enumの宣言順に、指定したエントリ列の順番が使われる。
+            Assert.That(entryNames, Is.EqualTo(new[] { "Folder_First", "Folder_Second", "Folder_Third" }));
+        }
+
+        [Test]
         public void AddEntry_EntryIsAdded()
         {
             var palette = new ColorPalette();

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ The setting to organize entries into folders can be changed from the following m
 
 If you choose not to organize entries into folders, all elements will be displayed flatly and can be rearranged via drag and drop.
 If you choose to organize entries into folders, they will be sorted in alphabetical order.
+Name Enum entries are generated in that alphabetical order when folders are used, or in the drag-and-drop order when they are not.
 
 ## Theme Feature Usage
 
@@ -290,6 +291,7 @@ To use it, attach the above component and setup UnityEvent to handle when the va
 When working with uPalette from script, it is useful to have a script automatically generated to access Theme and Entry information.
 
 If you set `Project Settings > uPalette > Name Enums File Generation`to`When Window Loses Focus`, this file will be automatically generated when the focus is lost from the Palette Editor or Theme Editor. If you set a folder to `Name Enums File Location`, the file will be generated in that folder. If not set, the file will be generated in the Assets folder.
+When this mode is enabled, the file is also regenerated when you change `Contains Folder Name to Name Enums`, `Name Enums File Location`, or `Use Folder View in Palette Editor`.
 
 <p align="center">
   <img width="70%" src="https://user-images.githubusercontent.com/47441314/158021815-2cec00b7-46f1-403b-b459-e03c8754b29d.png" alt="Project Settings">
@@ -329,6 +331,7 @@ The same can be used for other types of Entries and Themes.
 
 If you check the `Contains Folder Name to Name Enums` option in the project settings, the folder name will also be included in the Enums.
 If you uncheck this option, the name used for the Enums will exclude the folder name.
+This option only affects enum names; it does not change their order.
 
 #### Get / Monitor entry value from script
 If you want to get or monitor the entry value from script, you can use the `GetActiveValue()` method of each palette.

--- a/README_JA.md
+++ b/README_JA.md
@@ -224,6 +224,7 @@ PaletteEditorの左上のドロップダウンメニューから、パレット�
 
 フォルダ分けをしない場合には全ての要素がフラットに表示され、ドラッグ&ドロップで並び替えられます。  
 フォルダ分けをする場合には名前順に並び替えられます。
+Name Enumsのエントリも、フォルダ分けをする場合はこの名前順、しない場合はドラッグ&ドロップで指定した順に生成されます。
 
 ## テーマ機能の使い方
 
@@ -316,6 +317,7 @@ public class Example : MonoBehaviour
 ### エントリやテーマを表すEnumを自動生成する
 スクリプトからuPaletteを操作する場合、テーマやエントリの情報にアクセスするためのスクリプトを自動生成しておくと便利です。  
 `Project Settings > uPalette > Name Enums File Generation`を`When Window Loses Focus`に設定すると、Palette EditorやTheme Editorからフォーカスが外れた際にこのファイルが自動生成されます。  
+この設定では、`Contains Folder Name to Name Enums`、`Name Enums File Location`、`Use Folder View in Palette Editor`を変更した際にもファイルが自動生成されます。  
 `Name Enums File Location`にフォルダを指定するとそのフォルダに生成されます。未指定の場合にはAssetsフォルダ直下に生成されます。
 
 <p align="center">
@@ -356,6 +358,7 @@ public class Example
 
 なお、プロジェクト設定の`Contains Folder Name to Name Enums`にチェックを入れると、フォルダ名もEnumに含められます。  
 このチェックを外すと、フォルダ名を除外した名前がEnumに使用されます。
+この設定はEnum名だけに影響し、並び順は変更しません。
 
 #### スクリプトからエントリの値を取得・監視する
 スクリプトからエントリの値を取得したり監視するには、以下のように各Paletteの`GetActiveValue()`を使います。  


### PR DESCRIPTION
- Preserve drag-and-drop order in flat view and use hierarchical natural sorting in folder view.
- Generate Name Enums with the same ordering policy and refresh them when output-affecting settings change.
- Synchronize entry order during undo and redo, and add EditMode regression coverage.

Fixes #29